### PR TITLE
feat: updating username on firebase storage

### DIFF
--- a/lib/src/modules/settings/domain/usecases/update_username.dart
+++ b/lib/src/modules/settings/domain/usecases/update_username.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:sticker_swap_client/src/core/entities/user.dart';
+
+
+abstract class IUpdateUsername{
+  Future<bool> call (String userId, String username);
+}
+
+class UpdateUsernameImpl implements IUpdateUsername{
+
+  final _storage = FirebaseFirestore.instance;
+
+  @override
+  Future<bool> call(String userId, String username) async{
+    try{
+      
+      await _storage.collection("user").doc(userId).update({
+        "username": username,
+      });
+
+      return true;
+    }catch(e){
+      debugPrint(e.toString());
+    }
+
+    return false;
+  }
+
+}

--- a/lib/src/modules/settings/presenter/settings_bloc.dart
+++ b/lib/src/modules/settings/presenter/settings_bloc.dart
@@ -2,10 +2,12 @@ import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:sticker_swap_client/src/core/entities/user.dart';
+import 'package:sticker_swap_client/src/modules/settings/domain/usecases/update_username.dart';
 
 class SettingsBloc{
 
   final user= Modular.get<User>();
+  final updateUsernameUseCase = Modular.get<IUpdateUsername>();
 
   TextEditingController name = TextEditingController();
   TextEditingController email = TextEditingController();
@@ -15,6 +17,16 @@ class SettingsBloc{
     email.text= user.email!;
     name.text= user.name!;
     username.text= user.username ?? "";
+  }
+
+  Future<void> editUsername() async {
+    final editedUsername = username.text;
+    
+    if (await updateUsernameUseCase(user.id!, editedUsername)){
+      print(">>> Username successfully updated!");
+    } else { 
+      print(">>> [Error] it was not possible to update the username!");
+    }
   }
 
   void logout() async {

--- a/lib/src/modules/settings/presenter/settings_module.dart
+++ b/lib/src/modules/settings/presenter/settings_module.dart
@@ -2,13 +2,15 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:sticker_swap_client/src/modules/settings/presenter/settings_bloc.dart';
 import 'package:sticker_swap_client/src/modules/settings/presenter/settings_screen.dart';
+import 'package:sticker_swap_client/src/modules/settings/domain/usecases/update_username.dart';
 
 class SettingsModule extends WidgetModule{
   SettingsModule({super.key});
 
   @override
   List<Bind<Object>> get binds => [
-    Bind<SettingsBloc>((i) => SettingsBloc())
+    Bind<SettingsBloc>((i) => SettingsBloc()),
+    Bind<IUpdateUsername>((i) => UpdateUsernameImpl())
   ];
 
   @override

--- a/lib/src/modules/settings/presenter/settings_screen.dart
+++ b/lib/src/modules/settings/presenter/settings_screen.dart
@@ -90,6 +90,7 @@ class _SettingsScreenState extends ModularState<SettingsScreen, SettingsBloc> {
                         ),
                         labelText: 'Username',
                       ),
+                      onEditingComplete: controller.editUsername,
                     ),
                   ),
 
@@ -161,6 +162,4 @@ class _SettingsScreenState extends ModularState<SettingsScreen, SettingsBloc> {
       backgroundImage: image,
     );
   }
-
-
 }


### PR DESCRIPTION
# O que o PR adiciona:
- Usecase para atualização do `username` no Firebase Storage
- Função no `SettingsBloc` para chamar a função de usecase.